### PR TITLE
chore(deps): bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,8 @@ jobs:
           - python: "3.15"
             experimental: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
       - run: uv python install ${{ matrix.python }}
@@ -53,8 +53,8 @@ jobs:
           - python: "3.15t"
             experimental: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
       - name: Install Python ${{ matrix.python }}
@@ -86,10 +86,10 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Sonar needs full history
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version-file: ".python-version"
@@ -99,7 +99,7 @@ jobs:
         run: >
           uv run pytest -m "not integration" -v
           --cov-report=term --cov-report=xml --cov
-      - uses: SonarSource/sonarqube-scan-action@v5
+      - uses: SonarSource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   tests:
+    name: tests (${{ matrix.python }})
     runs-on: ubuntu-latest
     # 3.15 is still beta and ``granian``'s PyO3 0.27 doesn't support it yet;
     # the entry is kept as an early-signal channel until PyO3 catches up.
@@ -40,6 +41,7 @@ jobs:
         run: uv run --python ${{ matrix.python }} pytest -m "not integration" -v
 
   tests-ft:
+    name: tests (${{ matrix.python }})
     runs-on: ubuntu-latest
     # 3.15t is still beta (uv ships ``cpython-3.15.0b1+freethreaded``).
     continue-on-error: ${{ matrix.experimental || false }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
             experimental: true
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
       - run: uv python install ${{ matrix.python }}
@@ -54,7 +54,7 @@ jobs:
             experimental: true
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
       - name: Install Python ${{ matrix.python }}
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Sonar needs full history
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           python-version-file: ".python-version"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,16 +18,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
       - name: Sync docs deps
         run: uv sync --group docs
       - name: Build site
         run: uv run zensical build --clean
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -39,4 +39,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
       - name: Sync docs deps

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -16,10 +16,10 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version-file: ".python-version"

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           python-version-file: ".python-version"


### PR DESCRIPTION
## Summary
- Supersedes Dependabot PRs #5 and #6, which targeted a base from before the v0.6 rewrite and missed `docs.yaml`.
- Bumps all GitHub Actions to the latest major where one was available.

## Changes
| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v4 | v6 |
| `astral-sh/setup-uv` | v5 | v8 |
| `SonarSource/sonarqube-scan-action` | v5 | v8 |
| `actions/configure-pages` | v5 | v6 |
| `actions/upload-pages-artifact` | v4 | v5 |
| `actions/deploy-pages` | v4 | v5 |

`pypa/gh-action-pypi-publish` is left at `release/v1` (rolling tag).

## Notes
- `sonarqube-scan-action` v6 introduced a breaking change to `args` parsing; we don't pass `args:`, so this is a no-op for us.
- `checkout` v5 requires runner `v2.327.1+` and v6 requires `v2.329.0+` — both satisfied on GitHub-hosted runners.

## Test plan
- [ ] CI green on this PR (tests matrix, sonarcloud)
- [ ] Close Dependabot PRs #5 and #6 once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)